### PR TITLE
Fix overflows on mobile

### DIFF
--- a/frontend/components.js
+++ b/frontend/components.js
@@ -97,10 +97,10 @@ const Balance = connect('balance')(({balance}) =>
     h('h2', undefined, 'Balance'),
     h(
       'p',
-      undefined,
+      {class: 'balance-value'},
       h(
         'span',
-        {class: 'balance-value'},
+        undefined,
         isNaN(Number(balance)) ? balance : `${printAda(balance)}`
       ),
       h('img', {class: 'ada-sign', src: '/assets/ada.png'})
@@ -272,35 +272,39 @@ const TransactionHistory = connect('transactionHistory')(({transactionHistory}) 
     {class: ''},
     h('h2', undefined, 'Transaction History'),
     h(
-      'table',
-      undefined,
+      'div',
+      {class: 'transaction-history-wrapper'},
       h(
-        'thead',
-        undefined,
+        'table',
+        {undefined},
         h(
-          'tr',
+          'thead',
           undefined,
-          h('th', undefined, 'Time'),
-          h('th', undefined, 'Transaction'),
-          h('th', undefined, 'Movement (ADA)')
-        )
-      ),
-      h(
-        'tbody',
-        undefined,
-        ...transactionHistory.map((transaction) =>
           h(
             'tr',
             undefined,
+            h('th', undefined, 'Time'),
+            h('th', undefined, 'Transaction'),
+            h('th', undefined, 'Movement (ADA)')
+          )
+        ),
+        h(
+          'tbody',
+          undefined,
+          ...transactionHistory.map((transaction) =>
             h(
-              'td',
+              'tr',
               undefined,
-              h(PrettyDate, {
-                date: new Date(transaction.ctbTimeIssued * 1000),
-              })
-            ),
-            h('td', undefined, h(TransactionAddress, {address: transaction.ctbId})),
-            h('td', undefined, h(PrettyValue, {effect: transaction.effect}))
+              h(
+                'td',
+                undefined,
+                h(PrettyDate, {
+                  date: new Date(transaction.ctbTimeIssued * 1000),
+                })
+              ),
+              h('td', undefined, h(TransactionAddress, {address: transaction.ctbId})),
+              h('td', undefined, h(PrettyValue, {effect: transaction.effect}))
+            )
           )
         )
       )

--- a/public_wallet_app/css/styles.css
+++ b/public_wallet_app/css/styles.css
@@ -193,6 +193,7 @@ td {
 }
 .address-wrap {
   display: flex;
+  overflow: hidden;
 }
 .address-link {
   border: 1px solid var(--border);
@@ -874,6 +875,16 @@ td {
 .balance-value {
   font-weight: 300;
   font-size: 4.5rem;
+  word-wrap: break-word;
+}
+@media screen and (max-width: 640px) {
+  .balance-value {
+    font-size: 2.25rem;
+  }
+  .ada-sign {
+    height: 1.5rem;
+    margin-left: 0.5rem;
+  }
 }
 .transaction-id {
   font-size: 0.9rem;
@@ -933,6 +944,9 @@ td {
 .loading-button-wrapper {
   display: flex;
   justify-content: center;
+}
+.transaction-history-wrapper {
+  overflow: auto;
 }
 .pulse {
   box-shadow: 0 0 0 var(--brand-shadow);


### PR DESCRIPTION
Transaction history table was overflowing and forced whole page to scroll... Same thing for addresses in "receive" tab