### PR TITLE
Paper wallet support

### DIFF
--- a/frontend/components.js
+++ b/frontend/components.js
@@ -275,7 +275,7 @@ class UnlockClass extends Component {
             class: 'styled-input-nodiv styled-unlock-input',
             id: 'mnemonic-submitted',
             name: 'mnemonic-submitted',
-            placeholder: 'Enter twelve-word mnemonic',
+            placeholder: 'Enter 12-word mnemonic or paper wallet mnemonic',
             value: mnemonic,
             onInput: updateMnemonic,
             onBlur: checkForMnemonicValidationError,

--- a/frontend/components.js
+++ b/frontend/components.js
@@ -264,6 +264,11 @@ class UnlockClass extends Component {
       h(
         'div',
         {class: 'auth-section'},
+        h(
+          'div',
+          {class: 'centered-row margin-bottom'},
+          'Enter the 12-word wallet mnemonic or 27-word Daedalus paper wallet mnemonic'
+        ),
         mnemonicValidationError &&
           showMnemonicValidationError &&
           h('p', {class: 'alert error'}, translations[mnemonicValidationError.code]()),
@@ -275,7 +280,7 @@ class UnlockClass extends Component {
             class: 'styled-input-nodiv styled-unlock-input',
             id: 'mnemonic-submitted',
             name: 'mnemonic-submitted',
-            placeholder: 'Enter 12-word mnemonic or paper wallet mnemonic',
+            placeholder: 'Enter wallet mnemonic',
             value: mnemonic,
             onInput: updateMnemonic,
             onBlur: checkForMnemonicValidationError,

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@stablelib/chacha": "^0.7.2",
     "@stablelib/chacha20poly1305": "^0.10.2",
     "bignumber.js": "^6.0.0",
-    "bip39": "^2.5.0",
+    "bip39": "2.5.0",
     "blakejs": "^1.1.0",
     "body-parser": "^1.18.2",
     "bs58": "^4.0.1",

--- a/public_wallet_app/css/styles.css
+++ b/public_wallet_app/css/styles.css
@@ -855,6 +855,9 @@ div.box.box-auto {
 .margin-top {
   margin-top: 1rem;
 }
+.margin-bottom {
+  margin-bottom: 1rem;
+}
 .margin-r {
   margin-right: .5rem;
 }

--- a/test/tests/cardano-mnemonic-crypto-provider.js
+++ b/test/tests/cardano-mnemonic-crypto-provider.js
@@ -9,11 +9,12 @@ const derivePublic = require('../../wallet/helpers/derivePublic')
 
 const mnemonic1 = 'cruise bike bar reopen mimic title style fence race solar million clean'
 const mnemonic2 = 'logic easily waste eager injury oval sentence wine bomb embrace gossip supreme'
-const cryptoProvider1 = CardanoMnemonicCryptoProvider(mnemonic1, {})
-const cryptoProvider2 = CardanoMnemonicCryptoProvider(mnemonic2, {})
+const cryptoProvider1 = CardanoMnemonicCryptoProvider(mnemonic1, {}, true)
+const cryptoProvider2 = CardanoMnemonicCryptoProvider(mnemonic2, {}, true)
 const cryptoProvider3 = CardanoMnemonicCryptoProvider(
   'A859BCAD5DE4FD8DF3F3BFA24793DBA52785F9A98832300844F028FF2DD75A5FCD24F7E51D3A2A72AC85CC163759B1103EFB1D685308DCC6CD2CCE09F70C948501E949B5B7A72F1AD304F47D842733B3481F2F096CA7DDFE8E1B7C20A1ACAFBB66EE772671D4FEF6418F670E80AD44D1747A89D75A4AD386452AB5DC1ACC32B3',
-  {}
+  {},
+  true
 )
 
 const childIndex2 = 0xf9745151
@@ -96,10 +97,18 @@ describe('address generation from secret key', () => {
 
   const expectedAddress3 =
     'DdzFFzCqrhsf6sUbywd6FfZHfvmkT7drL7MLzs5KkvfSpTNLExLHhhwmuKdAajnHE3cebNPPkfyUYpoqgEV7ktDLUHF5dV41eWSMh6VU'
-  it('should properly generate some address from nonhardened key - child index starts with 0 in binary', async () => {
+  it('should properly generate some address from nonhardened key in hardened mode - child index starts with 0 in binary', async () => {
     const derivedAddress3 = await cryptoProvider3.deriveAddress(
       [HARDENED_THRESHOLD, childIndex3],
       'hardened'
+    )
+    assert.equal(derivedAddress3, expectedAddress3)
+  })
+
+  it('should properly generate some address from nonhardened key in nonhardened mode - child index starts with 0 in binary', async () => {
+    const derivedAddress3 = await cryptoProvider3.deriveAddress(
+      [HARDENED_THRESHOLD, childIndex3],
+      'nonhardened'
     )
     assert.equal(derivedAddress3, expectedAddress3)
   })

--- a/test/tests/mnemonic.js
+++ b/test/tests/mnemonic.js
@@ -1,11 +1,36 @@
 const assert = require('assert')
 
-const {generateMnemonic} = require('../../wallet/mnemonic')
+const {
+  generateMnemonic,
+  _decodePaperWalletMnemonic,
+  mnemonicToHashSeed,
+} = require('../../wallet/mnemonic')
+
+const paperWalletMnemonic =
+  'force usage medal chapter start myself odor ripple concert aspect wink melt afford lounge smart bulk way hazard burden type broken defense city announce reward same tumble'
+const standardMnemonic = 'swim average antenna there trap nice good stereo lion safe next brief'
+const expectedHashSeed = '5820f56bcbc3cea284f348db4e4e5ce4019fb991d909fee5ca35313229258c7735db'
 
 describe('mnemonic generation', () => {
   const mnemonicString = generateMnemonic()
 
   it('should produce 12 words', () => {
     assert.equal(mnemonicString.split(' ').length, 12)
+  })
+})
+
+describe('paper wallet decoding', () => {
+  it('should properly decode paper wallet mnemonic', async () => {
+    assert.equal(await _decodePaperWalletMnemonic(paperWalletMnemonic), standardMnemonic)
+  })
+})
+
+describe('mnemonic to hash seed conversion', () => {
+  it('should properly convert 12 word mnemonic to hash seed', async () => {
+    assert.equal((await mnemonicToHashSeed(standardMnemonic)).toString('hex'), expectedHashSeed)
+  })
+
+  it('should properly convert 27 word paper wallet mnemonic to hash seed', async () => {
+    assert.equal((await mnemonicToHashSeed(paperWalletMnemonic)).toString('hex'), expectedHashSeed)
   })
 })

--- a/wallet/cardano-mnemonic-crypto-provider.js
+++ b/wallet/cardano-mnemonic-crypto-provider.js
@@ -12,7 +12,11 @@ const {HdNode, mnemonicToHdNode, hdNodeStringToHdNode} = require('./hd-node')
 const derivePublic = require('./helpers/derivePublic')
 const {packAddress, unpackAddress} = require('./address')
 
-const CardanoMnemonicCryptoProvider = (mnemonicOrHdNodeString, walletState) => {
+const CardanoMnemonicCryptoProvider = (
+  mnemonicOrHdNodeString,
+  walletState,
+  disableCaching = false
+) => {
   const state = Object.assign(walletState, {
     masterHdNode:
       mnemonicOrHdNodeString.search(' ') >= 0
@@ -94,7 +98,7 @@ const CardanoMnemonicCryptoProvider = (mnemonicOrHdNodeString, walletState) => {
   function deriveXpub(derivationPath, derivationMode) {
     const memoKey = JSON.stringify(derivationPath)
 
-    if (!state.derivedXpubs[memoKey]) {
+    if (disableCaching || !state.derivedXpubs[memoKey]) {
       if (derivationMode === 'hardened') {
         state.derivedXpubs[memoKey] = deriveXpubHardened(derivationPath)
       } else if (derivationMode === 'nonhardened') {
@@ -125,7 +129,7 @@ const CardanoMnemonicCryptoProvider = (mnemonicOrHdNodeString, walletState) => {
 
   function deriveHdNode(derivationPath) {
     const memoKey = JSON.stringify(derivationPath)
-    if (!state.derivedHdNodes[memoKey]) {
+    if (disableCaching || !state.derivedHdNodes[memoKey]) {
       if (derivationPath.length > 2) {
         throw Error('Address derivation path should be of length at most 2')
       }

--- a/wallet/hd-node.js
+++ b/wallet/hd-node.js
@@ -1,11 +1,8 @@
-const bip39 = require('bip39')
-const cbor = require('cbor')
 const crypto = require('crypto')
 const {eddsa: EdDsa} = require('elliptic-cardano')
 const ec = new EdDsa('ed25519')
 
-const hashBlake2b256 = require('./helpers/hashBlake2b256')
-const {validateMnemonic} = require('./mnemonic')
+const {mnemonicToHashSeed} = require('./mnemonic')
 
 function HdNode({secretKey, publicKey, chainCode}) {
   /**
@@ -97,18 +94,6 @@ function extendSecretToSecretKey(secret) {
   }
 
   return hashResult
-}
-
-function mnemonicToHashSeed(mnemonic) {
-  if (!validateMnemonic(mnemonic)) {
-    const e = new Error('Invalid or unsupported mnemonic format')
-    e.name = 'InvalidArgumentException'
-    throw e
-  }
-
-  const ent = Buffer.from(bip39.mnemonicToEntropy(mnemonic), 'hex')
-
-  return cbor.encode(hashBlake2b256(cbor.encode(ent)))
 }
 
 module.exports = {

--- a/wallet/helpers/derivePublic.js
+++ b/wallet/helpers/derivePublic.js
@@ -1,7 +1,7 @@
-const CardanoRustCrypto = require('rust-cardanolite-crypto')
+const CardanoCrypto = require('rust-cardanolite-crypto')
 
 function derivePublic(xpub, childIndex) {
-  return new Buffer(CardanoRustCrypto.HdWallet.derivePublic(xpub, childIndex))
+  return new Buffer(CardanoCrypto.HdWallet.derivePublic(xpub, childIndex))
 }
 
 module.exports = derivePublic

--- a/wallet/helpers/pbkdf2.js
+++ b/wallet/helpers/pbkdf2.js
@@ -1,7 +1,7 @@
-const {pbkdf2} = require('pbkdf2')
+const {pbkdf2, pbkdf2Sync} = require('pbkdf2')
 
-async function pbkdf2Async(password, salt, iterations, length, algo) {
-  return await new Promise((resolveFunction, rejectFunction) => {
+function pbkdf2Async(password, salt, iterations, length, algo) {
+  return new Promise((resolveFunction, rejectFunction) => {
     pbkdf2(password, salt, iterations, length, algo, (error, response) => {
       if (error) {
         rejectFunction(error)
@@ -11,4 +11,7 @@ async function pbkdf2Async(password, salt, iterations, length, algo) {
   })
 }
 
-module.exports = {pbkdf2Async}
+module.exports = {
+  pbkdf2Async,
+  pbkdf2Sync,
+}

--- a/wallet/mnemonic.js
+++ b/wallet/mnemonic.js
@@ -1,4 +1,8 @@
 const bip39 = require('bip39')
+const cbor = require('cbor')
+
+const hashBlake2b256 = require('./helpers/hashBlake2b256')
+const {pbkdf2Sync} = require('./helpers/pbkdf2')
 
 const {words} = require('./valid-words.en')
 
@@ -8,13 +12,85 @@ function generateMnemonic() {
 
 function validateMnemonic(mnemonic) {
   try {
-    return !!mnemonic && bip39.validateMnemonic(mnemonic)
+    return !!mnemonic && (bip39.validateMnemonic(mnemonic) || isPaperWalletMnemonic(mnemonic))
   } catch (e) {
     return false
   }
 }
 
+function isPaperWalletMnemonic(mnemonic) {
+  return mnemonicToList(mnemonic).length === 27
+}
+
+function mnemonicToList(mnemonic) {
+  return mnemonic.split(' ')
+}
+
+function mnemonicToHashSeed(mnemonic) {
+  if (!validateMnemonic(mnemonic)) {
+    const e = new Error('Invalid or unsupported mnemonic format')
+    e.name = 'InvalidArgumentException'
+    throw e
+  }
+
+  if (isPaperWalletMnemonic(mnemonic)) {
+    mnemonic = decodePaperWalletMnemonic(mnemonic)
+  }
+
+  const ent = Buffer.from(bip39.mnemonicToEntropy(mnemonic), 'hex')
+
+  return cbor.encode(hashBlake2b256(cbor.encode(ent)))
+}
+
+function mnemonicToPaperWalletPassphrase(mnemonic, password) {
+  const mnemonicBuffer = Buffer.from(mnemonic, 'utf8')
+  const salt = `mnemonic${password || ''}`
+  const saltBuffer = Buffer.from(salt, 'utf8')
+  return pbkdf2Sync(mnemonicBuffer, saltBuffer, 2048, 32, 'sha512').toString('hex')
+}
+
+function decodePaperWalletMnemonic(paperWalletMnemonic) {
+  const paperWalletMnemonicAsList = mnemonicToList(paperWalletMnemonic)
+
+  if (paperWalletMnemonicAsList.length !== 27) {
+    throw Error(
+      `Paper Wallet Mnemonic must be 27 words, got ${paperWalletMnemonicAsList.length} instead`
+    )
+  }
+
+  const mnemonicScrambledPart = paperWalletMnemonicAsList.slice(0, 18).join(' ')
+  const mnemonicPassphrasePart = paperWalletMnemonicAsList.slice(18, 27).join(' ')
+
+  const passphrase = mnemonicToPaperWalletPassphrase(mnemonicPassphrasePart)
+  const unscrambledMnemonic = unscrambleStrings(passphrase, mnemonicScrambledPart)
+
+  return unscrambledMnemonic
+}
+
+// eslint-disable-next-line max-len
+/* taken from https://github.com/input-output-hk/rust-cardano/blob/08796d9f100f417ff30549b297bd20b249f87809/cardano/src/paperwallet.rs */
+function unscrambleStrings(passphrase, mnemonic) {
+  const input = Buffer.from(bip39.mnemonicToEntropy(mnemonic), 'hex')
+  const saltLength = 8
+
+  if (saltLength >= input.length) {
+    throw Error('unscrambleStrings: Input is too short')
+  }
+
+  const outputLength = input.length - saltLength
+
+  const output = pbkdf2Sync(passphrase, input.slice(0, saltLength), 10000, outputLength, 'sha512')
+
+  for (let i = 0; i < outputLength; i++) {
+    output[i] = output[i] ^ input[saltLength + i]
+  }
+
+  return bip39.entropyToMnemonic(output)
+}
+
 module.exports = {
   generateMnemonic,
   validateMnemonic,
+  mnemonicToHashSeed,
+  _decodePaperWalletMnemonic: decodePaperWalletMnemonic,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1234,7 +1234,7 @@ binaryextensions@2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.1.1.tgz#3209a51ca4a4ad541a3b8d3d6a6d5b83a2485935"
 
-bip39@^2.5.0:
+bip39@2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/bip39/-/bip39-2.5.0.tgz#51cbd5179460504a63ea3c000db3f787ca051235"
   dependencies:


### PR DESCRIPTION
Now you can insert into the input the 27 word paper wallet mnemonic and the wallet will get properly loaded. The proper way of working is shown in the tests (the "mnemonic.js" one). You can try loading the paper wallet string from the tests and see that the wallet was loaded by checking for the presence of the address "DdzFFzCqrhssvx7eAtDT2xbQtVeRVjCktAEg4sc3gmSFE6RFBadLVZX2e8ByfawtASMBeUtNMsyauaSSG2TP3Rgv3V94xLzmt67fJG4z" between the receive addresses. You can also generate the paper wallet yourself in Daedalus and verify that the first receive address to appear in cardanolite matches the one from the PDF generated by Daedalus. 