### PR TITLE
Remove transition from demo button to remove glitch

### DIFF
--- a/public_wallet_app/css/styles.css
+++ b/public_wallet_app/css/styles.css
@@ -913,6 +913,7 @@ div.box.box-auto {
   border: 1px solid var(--brand);
   color: black;
   margin-bottom: 1em;
+  transition: none;
 }
 .alt-button {
   font-weight: 600;


### PR DESCRIPTION
The demo button has blinking on right side of button when it was hovered. It is caused with transition and transform scale