### PR TITLE
fix: wrong mnemonic prevent new one or demo 

### DIFF
--- a/app/frontend/components/pages/login/generateMnemonicDialog.js
+++ b/app/frontend/components/pages/login/generateMnemonicDialog.js
@@ -27,9 +27,10 @@ module.exports = connect(
       h(
         'h7',
         undefined,
-        'Write these words down. Do not copy them to your clipboard or save them anywhere online.'
+        'Write these words down. ',
+        h('b', undefined, 'Do not copy them to your clipboard or save them anywhere online!')
       ),
-      h('div', {class: 'gray-row mnemonic-box no-events no-select'}, mnemonic),
+      h('div', {class: 'gray-row mnemonic-box'}, mnemonic),
       h('div', {class: ''}, h('button', {onClick: confirmGenerateMnemonicDialog}, 'Confirm'))
     )
   )

--- a/app/frontend/components/pages/login/mnemonicAuth.js
+++ b/app/frontend/components/pages/login/mnemonicAuth.js
@@ -13,8 +13,13 @@ const LoadByMenmonicSection = ({
   showGenerateMnemonicDialog,
   loadDemoWallet,
   showMnemonicValidationError,
-}) =>
-  h(
+}) => {
+  const isLeftClick = (e, action) => {
+    if (e.button === 0) {
+      action()
+    }
+  }
+  return h(
     'div',
     {class: 'auth-section'},
     h(
@@ -59,7 +64,12 @@ const LoadByMenmonicSection = ({
       'a',
       {
         class: 'intro-link fade-in-up',
-        onClick: openGenerateMnemonicDialog,
+        /*
+        * onMouseDown instead of onClick is there to prevent mnemonic field onBlur happen before onClick
+        * (validator will show err, which moves layout, so click might end outside the button)
+        * https://stackoverflow.com/questions/17769005/onclick-and-onblur-ordering-issue
+        */
+        onMouseDown: (e) => isLeftClick(e, openGenerateMnemonicDialog),
       },
       '…or generate a new one'
     ),
@@ -71,11 +81,17 @@ const LoadByMenmonicSection = ({
         'button',
         {
           class: 'demo-button rounded-button',
-          onClick: loadDemoWallet,
+          /*
+          * onMouseDown instead of onClick is there to prevent mnemonic field onBlur happen before onClick
+          * (validator will show err, which moves layout, so click might end outside the button)
+          * https://stackoverflow.com/questions/17769005/onclick-and-onblur-ordering-issue
+          */
+          onMouseDown: (e) => isLeftClick(e, loadDemoWallet),
         },
         'Try demo wallet'
       )
     )
   )
+}
 
 module.exports = LoadByMenmonicSection


### PR DESCRIPTION
closes #144 fix: enable selecting text in generateNewMnemonic dialog
closes #145 fix: wrong mnemonic prevent new one or demo -> err moves layout