### PR TITLE
show spinner until transaction appears in explorer

### DIFF
--- a/app/frontend/components/common/svg.js
+++ b/app/frontend/components/common/svg.js
@@ -21,7 +21,7 @@ const VacuumlabsLogo = () =>
     {
       xmlns: 'http://www.w3.org/2000/svg',
       viewBox: '0 0 192.8 39.7',
-      style: 'enable-background:new 0 0 192.8 39.7; ' + 'width: 9.64rem; height: 2rem;',
+      style: 'enable-background:new 0 0 192.8 39.7; width: 9.64rem; height: 2rem;',
     },
     h('style', undefined, '.st1{fill:#242f3c}'),
     h(

--- a/app/frontend/components/pages/login/loginPage.js
+++ b/app/frontend/components/pages/login/loginPage.js
@@ -1,7 +1,7 @@
 const {h, Component} = require('preact')
 const connect = require('unistore/preact').connect
 const actions = require('../../../actions')
-const translations = require('../../../translations')
+const {getTranslation} = require('../../../translations')
 
 const AboutOverlay = require('./aboutOverlay')
 const KeyFileAuth = require('./keyFileAuth')
@@ -53,7 +53,7 @@ class LoginPage extends Component {
           h(
             'p',
             {class: 'alert error'},
-            translations[walletLoadingError.code](walletLoadingError.params)
+            getTranslation(walletLoadingError.code, walletLoadingError.params)
           ),
         authMethod === 'mnemonic' &&
           MnemonicAuth({

--- a/app/frontend/components/pages/login/mnemonicAuth.js
+++ b/app/frontend/components/pages/login/mnemonicAuth.js
@@ -1,5 +1,5 @@
 const {h} = require('preact')
-const translations = require('../../../translations')
+const {getTranslation} = require('../../../translations')
 
 const GenerateMnemonicDialog = require('./generateMnemonicDialog')
 
@@ -29,7 +29,7 @@ const LoadByMenmonicSection = ({
     ),
     mnemonicValidationError &&
       showMnemonicValidationError &&
-      h('p', {class: 'alert error'}, translations[mnemonicValidationError.code]()),
+      h('p', {class: 'alert error'}, getTranslation(mnemonicValidationError.code)),
     h(
       'div',
       {class: 'intro-input-row'},
@@ -65,8 +65,7 @@ const LoadByMenmonicSection = ({
       {
         class: 'intro-link fade-in-up',
         /*
-        * onMouseDown instead of onClick is there to prevent mnemonic field onBlur happen before onClick
-        * (validator will show err, which moves layout, so click might end outside the button)
+        * onMouseDown to prevent onBlur before handling the click event
         * https://stackoverflow.com/questions/17769005/onclick-and-onblur-ordering-issue
         */
         onMouseDown: (e) => isLeftClick(e, openGenerateMnemonicDialog),
@@ -82,8 +81,7 @@ const LoadByMenmonicSection = ({
         {
           class: 'demo-button rounded-button',
           /*
-          * onMouseDown instead of onClick is there to prevent mnemonic field onBlur happen before onClick
-          * (validator will show err, which moves layout, so click might end outside the button)
+          * onMouseDown to prevent onBlur before handling the click event
           * https://stackoverflow.com/questions/17769005/onclick-and-onblur-ordering-issue
           */
           onMouseDown: (e) => isLeftClick(e, loadDemoWallet),

--- a/app/frontend/components/pages/send_ada/sendAdaPage.js
+++ b/app/frontend/components/pages/send_ada/sendAdaPage.js
@@ -2,7 +2,7 @@ const {h, Component} = require('preact')
 const connect = require('unistore/preact').connect
 const actions = require('../../../actions')
 
-const translations = require('../../../translations')
+const {getTranslation} = require('../../../translations')
 const printAda = require('../../../helpers/printAda')
 
 const ConfirmTransactionDialog = require('./confirmTransactionDialog')
@@ -57,7 +57,7 @@ class SendAdaPage extends Component {
                 'span',
                 undefined,
                 h('b', undefined, 'failed'),
-                `: ${translations[sendResponse.error]()}`
+                `: ${getTranslation(sendResponse.error, {sendResponse})}`
               )
           )
           : '',
@@ -66,7 +66,7 @@ class SendAdaPage extends Component {
           {class: 'row'},
           h('label', undefined, h('span', undefined, 'Receiving address')),
           sendAddressValidationError &&
-            h('span', {class: 'validationMsg'}, translations[sendAddressValidationError.code]())
+            h('span', {class: 'validationMsg'}, getTranslation(sendAddressValidationError.code))
         ),
         h('input', {
           type: 'text',
@@ -129,7 +129,7 @@ class SendAdaPage extends Component {
           h(
             'p',
             {class: 'validationMsg send-amount-validation-error'},
-            translations[sendAmountValidationError.code](sendAmountValidationError.params)
+            getTranslation(sendAmountValidationError.code, sendAmountValidationError.params)
           ),
         h(
           'div',

--- a/app/frontend/helpers/NamedError.js
+++ b/app/frontend/helpers/NamedError.js
@@ -1,0 +1,8 @@
+function NamedError(name, message) {
+  const e = new Error(message)
+  e.name = name
+
+  return e
+}
+
+module.exports = NamedError

--- a/app/frontend/helpers/sleep.js
+++ b/app/frontend/helpers/sleep.js
@@ -1,0 +1,5 @@
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+module.exports = sleep

--- a/app/frontend/translations.js
+++ b/app/frontend/translations.js
@@ -1,6 +1,7 @@
 const printAda = require('./helpers/printAda')
+const debugLog = require('./helpers/debugLog')
 
-module.exports = {
+const translations = {
   SendAddressInvalidAddress: () => 'Invalid address',
   SendAmountIsNan: () => 'Invalid format: Amount has to be a number',
   SendAmountIsNotPositive: () => 'Invalid format: Amount has to be a positive number',
@@ -18,5 +19,23 @@ module.exports = {
   TransactionRejectedByTrezor: () => 'Transaction rejected by the Trezor hardware wallet.',
   TrezorRejected: () => 'Operation rejected by the Trezor hardware wallet.',
   TransactionCorrupted: () => 'Transaction assembling failure.',
+  TransactionNotFoundInBlockchainAfterSubmission: ({sendResponse}) =>
+    `Transaction ${
+      sendResponse.txHash
+    } not found in blockchain after being submitted, check it later please.`,
   UnknownCryptoProvider: ({cryptoProvider}) => `Uknown crypto provider: ${cryptoProvider}`,
+  NetworkError: () => 'Network connection failed. Please check your network connection.',
+  Error: () => 'Unknown error, please contact support at cardanolite@vacuumlabs.com',
+}
+
+function getTranslation(code, params) {
+  if (!translations[code]) {
+    debugLog(`Translation for ${code} not found!`)
+  }
+
+  return translations[code] ? translations[code](params) : code
+}
+
+module.exports = {
+  getTranslation,
 }

--- a/app/frontend/wallet/address.js
+++ b/app/frontend/wallet/address.js
@@ -9,6 +9,8 @@ const {
 } = require('cardano-crypto.js')
 
 const CborIndefiniteLengthArray = require('./helpers/CborIndefiniteLengthArray')
+const NamedError = require('../helpers/NamedError')
+const debugLog = require('../helpers/debugLog')
 
 function getAddressHash(input) {
   // eslint-disable-next-line camelcase
@@ -36,9 +38,8 @@ function decryptDerivationPath(addressPayload, hdPassphrase) {
   try {
     return cbor.decode(Buffer.from(decipheredDerivationPath))
   } catch (err) {
-    const e = new Error('incorrect address or passphrase')
-    e.name = 'AddressDecodingException'
-    throw e
+    debugLog(err)
+    throw NamedError('AddressDecodingException', 'incorrect address or passphrase')
   }
 }
 

--- a/app/frontend/wallet/blockchain-explorer.js
+++ b/app/frontend/wallet/blockchain-explorer.js
@@ -36,6 +36,15 @@ const blockchainExplorer = (CARDANOLITE_CONFIG, walletState) => {
     return Object.values(transactions).sort((a, b) => b.ctbTimeIssued - a.ctbTimeIssued)
   }
 
+  async function fetchTxInfo(txHash) {
+    const url = `${
+      CARDANOLITE_CONFIG.CARDANOLITE_BLOCKCHAIN_EXPLORER_URL
+    }/api/txs/summary/${txHash}`
+    const result = await request(url)
+
+    return result.Right
+  }
+
   async function fetchTxRaw(txId) {
     // eslint-disable-next-line no-undef
     const url = `${CARDANOLITE_CONFIG.CARDANOLITE_BLOCKCHAIN_EXPLORER_URL}/api/txs/raw/${txId}`
@@ -101,30 +110,17 @@ const blockchainExplorer = (CARDANOLITE_CONFIG, walletState) => {
   }
 
   async function submitTxRaw(txHash, txBody) {
-    try {
-      const res = await request(
-        CARDANOLITE_CONFIG.CARDANOLITE_TRANSACTION_SUBMITTER_URL,
-        'POST',
-        JSON.stringify({
-          txHash,
-          txBody,
-        }),
-        {
-          'Content-Type': 'application/json',
-        }
-      )
-
-      if (res.status >= 400) {
-        throw Error(`${res.status} ${JSON.stringify(res)}`)
-      } else {
-        if (res.result) {
-          return res.result
-        }
-        throw new Error(`Cardano network rejected the transaction ${JSON.stringify(res)}`)
+    return await request(
+      CARDANOLITE_CONFIG.CARDANOLITE_TRANSACTION_SUBMITTER_URL,
+      'POST',
+      JSON.stringify({
+        txHash,
+        txBody,
+      }),
+      {
+        'Content-Type': 'application/json',
       }
-    } catch (err) {
-      throw err //Error(`txSubmiter unreachable ${err}`)
-    }
+    )
   }
 
   async function fetchUnspentTxOutputs(addresses) {
@@ -152,7 +148,6 @@ const blockchainExplorer = (CARDANOLITE_CONFIG, walletState) => {
   }
 
   async function fetchAddressInfo(address) {
-    // eslint-disable-next-line no-undef
     const url = `${
       CARDANOLITE_CONFIG.CARDANOLITE_BLOCKCHAIN_EXPLORER_URL
     }/api/addresses/summary/${address}`
@@ -171,6 +166,7 @@ const blockchainExplorer = (CARDANOLITE_CONFIG, walletState) => {
     selectUnusedAddresses,
     submitTxRaw,
     getBalance,
+    fetchTxInfo,
   }
 }
 

--- a/app/frontend/wallet/helpers/request.js
+++ b/app/frontend/wallet/helpers/request.js
@@ -1,3 +1,6 @@
+const NamedError = require('../../helpers/NamedError')
+const debugLog = require('../../helpers/debugLog')
+
 const request = async function request(url, method = 'GET', body = null, headers = {}) {
   let requestParams = {
     method,
@@ -8,21 +11,18 @@ const request = async function request(url, method = 'GET', body = null, headers
   }
 
   try {
-    const res = await fetch(url, requestParams)
-    if (res.status >= 400) {
-      const e = Error(
-        `${url} returns error: ${res.status} on payload: ${JSON.stringify(requestParams)}`
+    const response = await fetch(url, requestParams)
+    if (response.status >= 400) {
+      throw NamedError(
+        'NetworkError',
+        `${url} returns error: ${response.status} on payload: ${JSON.stringify(requestParams)}`
       )
-      e.name = 'Network error'
-      throw e
     }
-    return res.json()
-  } catch (err) {
-    const e = Error(
-      `${url} returns ${err.name}:  ${err.message} on payload: ${JSON.stringify(requestParams)}`
-    )
-    e.name = 'Network error'
-    throw e
+
+    return response.json()
+  } catch (e) {
+    debugLog(e)
+    throw NamedError('NetworkError', `${method} ${url} returns error: ${e}`)
   }
 }
 

--- a/server/transactionSubmitter.js
+++ b/server/transactionSubmitter.js
@@ -24,7 +24,7 @@ module.exports = function(app, env) {
       return res.status(500).send('bad request format')
     }
 
-    // res.end(JSON.stringify({result: true, txHash}))
+    // return res.end(JSON.stringify({success: true, txHash}))
 
     txBody = `8201${txBody}`
 
@@ -34,7 +34,7 @@ module.exports = function(app, env) {
     const encodedTx = (txBody.length / 2).toString(16).padStart(8, '0') + txBody
     let code = ''
     let phase = 'not connected'
-    let result = false
+    let success = false
 
     const client = new net.Socket()
     client.connect({host: 'relays.cardano-mainnet.iohk.io', port: 3000})
@@ -113,13 +113,13 @@ module.exports = function(app, env) {
             phase = 'result'
             break
           case 'result':
-            result = data.toString('hex').endsWith('f5')
+            success = data.toString('hex').endsWith('f5')
             client.write(Buffer.from('0000000100000402', 'hex'))
             phase = 'done'
             break
           default:
             client.destroy()
-            res.end(JSON.stringify({result, txHash}))
+            res.end(JSON.stringify({success, txHash}))
         }
       } catch (err) {
         return res


### PR DESCRIPTION
The spinner now should be displayed until the transaction actually appears in the blockchain explorer, so the user won't be confused.

If the transaction fails to appear within ~100 seconds (20 retries * 5s sleep), an error should be displayed where the user is notified about the transaction id, so he can check it later.

I also refactored and fixed error handling when submitting transactions. I added NamedError helper. Most of the errors were not displayed/handled propery, since they did not make it to the "sendResponse" state variable.

I also refactored translations so they have a nicer API and fail gracefully if translation code is not present