### PR TITLE
added transactions counter to stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "dotenv": "^6.0.0",
     "express": "^4.16.3",
     "express-basic-auth": "^1.1.5",
+    "express-mung": "^0.5.1",
     "isomorphic-fetch": "^2.2.1",
     "redis": "^2.8.0",
     "redisscan": "^2.0.0"

--- a/server/index.js
+++ b/server/index.js
@@ -17,7 +17,8 @@ if (process.env.CARDANOLITE_FORCE_HTTPS === 'true') {
 
 // don't track in local dev => no need for local redis
 if (process.env.REDIS_URL) {
-  app.use(require('./middlewares/stats'))
+  app.use(require('./middlewares/stats').trackVisits)
+  app.use(require('./middlewares/stats').trackTxSubmissionCount)
   app.use(require('./middlewares/basicAuth')(['/usage_stats'], {admin: process.env.STATS_PWD}))
   require('./statsPage')(app)
 }
@@ -39,6 +40,7 @@ app.get('*', (req, res) => {
 
     <head>
       <title>CardanoLite Wallet</title>
+      <meta charset="utf-8"/>
       <meta name="viewport" content="width=device-width, initial-scale=1">
       <script src="js/init.js"></script>
       <link rel="stylesheet" type="text/css" href="css/styles.css">

--- a/server/mocking.js
+++ b/server/mocking.js
@@ -14,11 +14,9 @@ module.exports = function(app, env) {
       txBody = req.body.txBody // [1, txBody] in CBOR
       if (!txHash || !txBody) throw new Error('bad format')
     } catch (err) {
-      return res.send(
-        JSON.stringify({
-          Left: 'Bad request body',
-        })
-      )
+      return res.json({
+        Left: 'Bad request body',
+      })
     }
 
     await sleep(5000)
@@ -26,16 +24,12 @@ module.exports = function(app, env) {
     const success = process.env.CARDANOLITE_MOCK_TX_SUBMISSION_SUCCESS === 'true'
 
     return success
-      ? res.end(
-        JSON.stringify({
-          Right: {txHash},
-        })
-      )
-      : res.end(
-        JSON.stringify({
-          Left: 'Transaction rejected by network',
-        })
-      )
+      ? res.json({
+        Right: {txHash},
+      })
+      : res.json({
+        Left: 'Transaction rejected by network',
+      })
   })
 
   app.get('/api/txs/summary/:txHash', async (req, res) => {
@@ -55,18 +49,18 @@ module.exports = function(app, env) {
 
     await sleep(1000)
 
-    return res.send(JSON.stringify(response))
+    return res.json(response)
   })
 
   // the remaining requests are redirected to the actual blockchain explorer
   app.get('/api/*', async (req, res) => {
-    return res.send(
+    return res.json(
       await request(`${process.env.CARDANOLITE_BLOCKCHAIN_EXPLORER_URL}${req.originalUrl}`)
     )
   })
 
   app.post('/api/*', async (req, res) => {
-    return res.send(
+    return res.json(
       await request(
         `${process.env.CARDANOLITE_BLOCKCHAIN_EXPLORER_URL}${req.originalUrl}`,
         'POST',

--- a/server/transactionSubmitter.js
+++ b/server/transactionSubmitter.js
@@ -21,11 +21,9 @@ module.exports = function(app, env) {
       txBody = req.body.txBody // [1, txBody] in CBOR
       if (!txHash || !txBody) throw new Error('bad format')
     } catch (err) {
-      return res.send(
-        JSON.stringify({
-          Left: 'Bad request body',
-        })
-      )
+      return res.json({
+        Left: 'Bad request body',
+      })
     }
 
     txBody = `8201${txBody}`
@@ -50,11 +48,9 @@ module.exports = function(app, env) {
     try {
       client.on('connect', initHandshake)
     } catch (err) {
-      res.status(200).send(
-        JSON.stringify({
-          Left: 'Connection to transaction submission node failed',
-        })
-      )
+      res.json({
+        Left: 'Connection to transaction submission node failed',
+      })
     }
 
     // eslint-disable-next-line consistent-return
@@ -126,35 +122,25 @@ module.exports = function(app, env) {
           default:
             client.destroy()
             if (!success) {
-              return res.end(
-                JSON.stringify({
-                  Left: 'Transaction rejected by network',
-                })
-              )
-            }
-            return res.end(
-              JSON.stringify({
-                Right: {
-                  txHash,
-                },
+              return res.json({
+                Left: 'Transaction rejected by network',
               })
-            )
+            }
+            return res.json({
+              Right: {txHash},
+            })
         }
       } catch (err) {
-        return res.status(200).send(
-          JSON.stringify({
-            Left: 'Transaction submission unexpectedly failed',
-          })
-        )
+        return res.json({
+          Left: 'Transaction submission unexpectedly failed',
+        })
       }
     })
 
     client.on('error', (err) => {
-      return res.status(200).send(
-        JSON.stringify({
-          Left: `Unexpected error on submission node: ${err}`,
-        })
-      )
+      return res.json({
+        Left: `Unexpected error on submission node: ${err}`,
+      })
     })
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -921,6 +921,10 @@ express-basic-auth@^1.1.5:
   dependencies:
     basic-auth "^1.1.0"
 
+express-mung@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/express-mung/-/express-mung-0.5.1.tgz#403ca3710745a208c676f1024314f1ead139919a"
+
 express@^4.16.3:
   version "4.16.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.3.tgz#6af8a502350db3246ecc4becf6b5a34d22f7ed53"


### PR DESCRIPTION
Added counter of transaction submissions whether they are successful or not. The results should appear in the stats page as soon as you attempt to submit a transaction, if you have set the REDIS_URL properly in .env

I initially tried to filter out unsuccessful tx submission attempts, but I did not find a nice way to intercept the content of the response, maybe you can suggest something.